### PR TITLE
Use sent in $ parameter

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -8,7 +8,7 @@
             'action': 'cilamp_ajax_action',
         };
 
-        jQuery.post(cilamp_ajax.ajax_url, data, function(response) {
+        $.post(cilamp_ajax.ajax_url, data, function(response) {
             console.log('Got this from the server: ' + response);
         });
     });


### PR DESCRIPTION
I believe this is a "convention break" even if it will work in practice (you should only use the $ which is sent into the function, not the implicit/global jQuery object)